### PR TITLE
Update supported Laravel versions; Package autodiscovery

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,4 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the `InterFAX notification channel` will be documented in this file
+
+## 2.0.0 - 2020-07-15
+
+- Add support for Laravel 7.x
+- Drop support for Laravel 5.8
+- Add package autodiscovery
+
+## 1.0.0 - 2020-01-08
+
+- Initial release

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\Interfax\\InterfaxServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/notifications": "5.8.*|^6.0",
-        "illuminate/support": "5.8.*|^6.0",
+        "illuminate/notifications": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
         "interfax/interfax": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
         "mpdf/mpdf": "^8.0",
-        "orchestra/testbench": "~3.8|~4.0",
+        "orchestra/testbench": "~4.0|~5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
- Support Laravel 7
- Drop support for Laravel 5.8 (EOL'd 2019/8/26, security support ended 2020/2/26)
- Add package autodiscovery